### PR TITLE
Fix typos and organize for stage 01-03

### DIFF
--- a/stage01/README.md
+++ b/stage01/README.md
@@ -1,6 +1,6 @@
 # Stage 01
 
-It shows how to build a single file to produce an executable application.
+Here we show how to build a single file to produce an executable application.
 
 ## Getting started
 
@@ -8,19 +8,19 @@ It shows how to build a single file to produce an executable application.
 
 To build this example, use
 
-```
+```shell
 bazel build //main:hello-world
 ```
 
 or
 
-```
+```shell
 bazel build //...
 ```
 
-If the build is successful, Bazel prints the output similar to
+If the build is successful, Bazel prints an output similar to
 
-```
+```shell
 INFO: Analyzed target //main:hello-world (0 packages loaded, 0 targets configured).
 INFO: Found 1 target...
 Target //main:hello-world up-to-date:
@@ -34,19 +34,19 @@ INFO: Build completed successfully, 3 total actions
 
 To run this example, use
 
-```
+```shell
 bazel run //main:hello-world
 ```
 
 or
 
-```
+```shell
 bazel run //...
 ```
 
-If the build is successful, Bazel prints the output similar to
+If the build is successful, Bazel prints an output similar to
 
-```
+```shell
 INFO: Analyzed target //main:hello-world (0 packages loaded, 0 targets configured).
 INFO: Found 1 target...
 Target //main:hello-world up-to-date:
@@ -59,32 +59,19 @@ Hello world
 Thu Jul 11 18:07:29 2024
 ```
 
-## BUILD File
-
-A `BUILD` file is the main configuration file that tells Bazel what software outputs to build, what their dependencies are, and how to build them. Bazel takes a `BUILD` file as input and uses the file to create a graph of dependencies and to derive the actions that must be completed to build intermediate and final software outputs. The file can also be named `BUILD.bazel`.
-
-This `BUILD.bazel` file in Stage 01 shows that we want to build a C++ binary using the `cc_binary` rule provided by Bazel. In the `cc_binary` rule, name of the binary is specified in name attribute (in this example, it's hello-world), required source files to be built are provided in srcs attribute.
-
-```python
-cc_binary(
-    name = "hello-world",
-    srcs = ["hello-world.cc"],
-)
-```
-
 ## WORKSPACE
 
 The `WORKSPACE` file in Bazel defines the root directory of a Bazel project. It is used to set up external dependencies and configure the overall build environment. Key components typically found in a `WORKSPACE` file include:
 
-- `External Repository Rules`: Rules like http_archive, git_repository, and local_repository to fetch and use external code.
-- `Load Statements`: Load custom macros and functions for better organization and reuse.
-- `Dependency Management`: Specify third-party libraries and modules your project depends on.
+- `External Repository Rules`: Fetches and uses external code. Examples include `http_archive`, `git_repository`, and `local_repository`.
+- `Load Statements`: Loads custom macros and functions for better organization and reuse.
+- `Dependency Management`: Specifies third-party libraries and modules your project depends on.
 
-In Stage 01, it is used only to define the root directory and is left as an empty file.
+In Stage 01, the `WORKSPACE` file is only used to define the root directory and is left empty.
 
 ## `load()` statement
 
-```
+```shell
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 ```
 
@@ -92,7 +79,13 @@ Bazel extensions are files ending in `.bzl`. Use the load statement to import a 
 
 The [`@rules_cc//cc:defs.bzl` file](https://github.com/bazelbuild/rules_cc/blob/main/cc/defs.bzl) is part of the [rules_cc repository](https://github.com/bazelbuild/rules_cc), which provides Bazel rules for compiling C and C++ code. This file typically contains definitions and macros for configuring and building C/C++ targets within a [Bazel project](https://github.com/bazelbuild).
 
-## `cc_binary` rule
+## BUILD File
+
+A `BUILD` file is the main configuration file that tells Bazel what software outputs to build, what their dependencies are, and how to build them. Bazel takes a `BUILD` file as input and uses the file to create a graph of dependencies and to derive the actions that must be completed to build intermediate and final software outputs. The file can be named `BUILD` or `BUILD.bazel`.
+
+### `cc_binary` rule (1)
+
+The `BUILD.bazel` file in Stage 01 shows that we want to build an executable C++ binary using the `cc_binary` rule provided by Bazel. 
 
 ```python
 cc_binary(
@@ -101,9 +94,7 @@ cc_binary(
 )
 ```
 
-It produces an executable binary.
+#### Arguments
 
-### Arguments
-
-1. `name`: The name of the binary target. A unique name for this target.
-2. `srcs`: A list of source files to compile. The `srcs` argument specifies the source files that are used to build the binary. These source files typically include `.cc` (C++ source files), `.c` (C source files), and other files that are directly compiled into the binary.
+1. `name`: The name of the binary target. This target name must be unique.
+2. `srcs`: A list of source files to compile. These source files typically include `.cc` (C++ source files), `.c` (C source files), and other files that are directly compiled into the binary.

--- a/stage02/README.md
+++ b/stage02/README.md
@@ -1,6 +1,6 @@
 # Stage 02
 
-Here, we introduce the `cc_library` rule for building C++ libraries.
+Here we introduce the `cc_library` rule for building C++ libraries.
 
 ## Getting started
 
@@ -19,7 +19,7 @@ or
 bazel build //...
 ```
 
-If the build is successful, Bazel prints the output similar to
+If the build is successful, Bazel prints an output similar to
 
 ```shell
 INFO: Analyzed 2 targets (83 packages loaded, 392 targets configured).
@@ -37,7 +37,7 @@ To run this example, use
 bazel run //main:hello-world
 ```
 
-If the run is successful, Bazel prints the output similar to
+If the run is successful, Bazel prints an output similar to
 
 ```shell
 INFO: Analyzed target //main:hello-world (0 packages loaded, 0 targets configured).
@@ -52,13 +52,13 @@ Hello world
 Thu Jul 11 18:56:13 2024
 ```
 
-If you enter the command below to run
+In this example, if the following statment is run,...
 
 ```shell
 bazel run //...
 ```
 
-You will see an error message like this:
+...you will see an error message like this:
 
 ```shell
 ERROR: Only a single target can be run. Your target pattern //... expanded to the targets //main:hello-greet, //main:hello-world
@@ -70,9 +70,9 @@ ERROR: Build failed. Not running target
 
 ## `tags = ["manual"]`
 
-The `tags = ["manual"]` line ensures that `bazel run //...` does not include this target in its execution, preventing cc_library targets from being run inadvertently.
+To remove a target from execution when running  `bazel run //...`, include the line `tags = ["manual"]` in the target.
 
-To resolve the previous error, you can modify it as follows:
+The previous error can be resolved by adding `tags = ["manual"]` to our `hello-greet` target as follows:
 
 ```python
 # BUILD.bazel
@@ -88,7 +88,7 @@ cc_library( # rule function
 
 ## Packages
 
-A package is defined as a directory containing a `BUILD` file named either `BUILD` or `BUILD.bazel`. Packages are the unit of granularity for deciding whether or not to allow access.
+A package is defined as a directory containing a `BUILD` file named either `BUILD` or `BUILD.bazel`. It is also seen as a container of the targets defined in said file.Packages are the unit of granularity for deciding whether or not to allow access.
 
 The primary unit of code organization in a repository is the package. A package is a collection of related files and a specification of how they can be used to produce output artifacts.
 
@@ -104,7 +104,7 @@ src/my/app/tests/test.cc
 
 ## Targets
 
-A package is a container of targets, which are defined in the package's `BUILD` file. Most targets are one of two principal kinds, files and rules.
+Targets are defined in the `BUILD` file. Most targets are one of two principal types: a file or a rule.
 
 ## Labels
 
@@ -126,7 +126,7 @@ A label is an identifier for a target. A typical label in its full canonical for
 //my/app/main:app_binary
 ```
 
-When the label refers to the same package it is used in, the package name (and optionally, the colon) may be omitted. So this label may be written either of the following ways:
+When the label refers to a target in the same package it is used in, the package name (and optionally, the colon) may be omitted. So this label may be written in either of the following ways:
 
 ```shell
 :app_binary
@@ -138,13 +138,13 @@ or
 app_binary
 ```
 
-## `cc_binary` rule
+## `cc_binary` rule (2)
 
 ### Arguments
 
-1. `deps`: Dependencies required to build the binary, such as libraries defined in other targets.
+1. `deps`: A list of the ependencies required to build the binary, such as libraries defined from other targets.
 
-## `cc_library` rule
+## `cc_library` rule (1)
 
 Use `cc_library()` for C++-compiled libraries.
 

--- a/stage03/README.md
+++ b/stage03/README.md
@@ -18,7 +18,7 @@ or
 bazel build //...
 ```
 
-If the build is successful, Bazel prints the output similar to
+If the build is successful, Bazel prints and output similar to
 
 ```shell
 INFO: Analyzed 3 targets (85 packages loaded, 395 targets configured).
@@ -36,7 +36,7 @@ To run this example, use
 bazel run //main:hello-world
 ```
 
-If the run is successful, Bazel prints the output similar to
+If the run is successful, Bazel prints an output similar to
 
 ```shell
 INFO: Analyzed target //main:hello-world (0 packages loaded, 0 targets configured).
@@ -53,7 +53,7 @@ Fri Jul 12 13:23:10 2024
 
 ## `visibility` attribute
 
-Below, we see a similar configuration from Stage 2, except that this `BUILD` file is in a subdirectory called lib. In Bazel, subdirectories containing `BUILD` files are known as packages. The new property `visibility` will tell Bazel which package(s) can reference this target, in this case the `//main` package can use `hello-time` library.
+Below, we see a similar configuration from Stage 2, except that this `BUILD` file is in a subdirectory called `lib`. In Bazel, subdirectories containing `BUILD` files are known as packages. The new property `visibility` will tell Bazel which package(s) can reference this target. In this case, the `//main` package can use `hello-time` library.
 
 ```python
 cc_library(
@@ -64,7 +64,7 @@ cc_library(
 )
 ```
 
-To use our `hello-time` library, an extra dependency is added in the form of `//path/to/package:target_name`, in this case, it's `//lib:hello-time`.
+To use a library, add a dependency in the form of `//path/to/package:library_target_name`. In this case, to add `hello-greet` to `hello-world`, add the dependency `//lib:hello-time`.
 
 ```python
 cc_binary(
@@ -82,4 +82,4 @@ cc_binary(
 1. `"//visibility:public"`: Grants access to all packages. (May not be combined with any other specification.)
 2. `"//visibility:private"`: Does not grant any additional access; only targets in this package can use this target. (May not be combined with any other specification.)
 3. `"//main:__pkg__"`: Grants access to `//main` (but not its subpackages).
-4. `"//main:__subpackages__"`: Grants access `//main` and all of its direct and indirect subpackages.(sets the visibility so that all targets in the main package and its subpackages can depend on this target.)
+4. `"//main:__subpackages__"`: Grants access to `//main` and all of its direct and indirect subpackages. (Sets the visibility so that all targets in the main package and its subpackages can depend on this target.)


### PR DESCRIPTION
Fixes typos and organizes sections in the `README.md` docs for stage 01-03. Some changes were made liberally, so feel free to ask about any change.